### PR TITLE
Add branch check to review destroys.

### DIFF
--- a/.github/workflows/review-destroy.yml
+++ b/.github/workflows/review-destroy.yml
@@ -41,7 +41,9 @@ env:
 
 jobs:
   destroy:
-    if: github.event.ref_type == 'branch'
+    if: |
+      github.event.ref_type == 'branch' && 
+      (startsWith(github.event.ref, 'review/') || startsWith(github.event.ref, 'feature/'))
     runs-on: self-hosted
     container:
       image: ${{ inputs.image }}


### PR DESCRIPTION
### Junior Review:
No

### Context:
Currently the review destroys are being triggered by any branch deletion this adds a check before the Jobs are ran to make sure we are on a review branch.

### Added:
- Check for if we are on a review branch before running the jobs.
