### PR TITLE
Add npmrc task to production workflow

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -74,6 +74,13 @@ jobs:
       - name: Download environment file via Deployer
         run: dep aws:download-env-file production --no-interaction
 
+      - name: Create .npmrc
+        uses: bikutadesu/create-npmrc@v1.0.0
+        with:
+          org_name: "destinationcore"
+          auth_token: "${{ secrets.GITHUB_PAT }}"
+          always_auth: true
+
       - name: Install NPM packages
         run: npm ci
 


### PR DESCRIPTION
### Junior Review:
No

### Context:
Adds the same npmrc task to the production workflow that we use in the staging workflow.

### Added:
- `Create .npmrc` task to the production workflow.
