### PR TITLE
Remove environment jobs

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -47,18 +47,7 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       image: ${{ inputs.image }}
-    outputs:
-      deployment_id: ${{ steps.deployment.outputs.deployment_id }}
     steps:
-      - name: Set GitHub deployment status
-        uses: chrnorm/deployment-action@releases/v1
-        id: deployment
-        with:
-          environment: Production
-          initial_status: "pending"
-          target_url: "https://${{ inputs.domain }}"
-          token: "${{ github.token }}"
-
       - name: Checkout repository
         uses: actions/checkout@v2
 
@@ -95,15 +84,6 @@ jobs:
             web/mix-manifest.json
             web/assets
           retention-days: 1
-
-      - name: Update GitHub deployment status (failure)
-        if: failure()
-        uses: chrnorm/deployment-status@releases/v1
-        with:
-          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          target_url: "https://${{ inputs.domain }}"
-          state: "failure"
-          token: "${{ github.token }}"
 
   deploy:
     runs-on: self-hosted
@@ -145,21 +125,3 @@ jobs:
           eval `ssh-agent -s`
           echo "${{ secrets.SSH_PRIVATE_KEY }}" | tr -d '\r' | ssh-add - > /dev/null
           dep deploy production --no-interaction
-
-      - name: Update GitHub deployment status (success)
-        if: success()
-        uses: chrnorm/deployment-status@releases/v1
-        with:
-          deployment_id: ${{ needs.build.outputs.deployment_id }}
-          target_url: "https://${{ inputs.domain }}"
-          state: "success"
-          token: "${{ github.token }}"
-
-      - name: Update GitHub deployment status (failure)
-        if: failure()
-        uses: chrnorm/deployment-status@releases/v1
-        with:
-          deployment_id: ${{ needs.build.outputs.deployment_id }}
-          target_url: "https://${{ inputs.domain }}"
-          state: "failure"
-          token: "${{ github.token }}"

--- a/.github/workflows/review-deploy.yml
+++ b/.github/workflows/review-deploy.yml
@@ -46,20 +46,9 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       image: ${{ inputs.image }}
-    outputs:
-      deployment_id: ${{ steps.deployment.outputs.deployment_id }}
     steps:
       - name: Get review name
         run: echo "REVIEW_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
-
-      - name: Set GitHub deployment status
-        uses: chrnorm/deployment-action@releases/v1
-        id: deployment
-        with:
-          environment: "Review: ${{ env.REVIEW_NAME }}"
-          initial_status: "pending"
-          target_url: "https://${{ github.event.repository.name }}_${{ env.REVIEW_NAME }}.${{ inputs.url_suffix }}/"
-          token: "${{ github.token }}"
 
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -100,15 +89,6 @@ jobs:
             web/mix-manifest.json
             web/assets
           retention-days: 1
-
-      - name: Update GitHub deployment status (failure)
-        if: failure()
-        uses: chrnorm/deployment-status@releases/v1
-        with:
-          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          target_url: "https://${{ github.event.repository.name }}_${{ env.REVIEW_NAME }}.${{ inputs.url_suffix }}/"
-          state: "failure"
-          token: "${{ github.token }}"
 
   deploy:
     runs-on: self-hosted
@@ -153,21 +133,3 @@ jobs:
           eval `ssh-agent -s`
           echo "${{ secrets.SSH_PRIVATE_KEY }}" | tr -d '\r' | ssh-add - > /dev/null
           dep deploy review --no-interaction
-
-      - name: Update GitHub deployment status (success)
-        if: success()
-        uses: chrnorm/deployment-status@releases/v1
-        with:
-          deployment_id: ${{ needs.build.outputs.deployment_id }}
-          target_url: "https://${{ github.event.repository.name }}_${{ env.REVIEW_NAME }}.${{ inputs.url_suffix }}/"
-          state: "success"
-          token: "${{ github.token }}"
-
-      - name: Update GitHub deployment status (failure)
-        if: failure()
-        uses: chrnorm/deployment-status@releases/v1
-        with:
-          deployment_id: ${{ needs.build.outputs.deployment_id }}
-          target_url: "https://${{ github.event.repository.name }}_${{ env.REVIEW_NAME }}.${{ inputs.url_suffix }}/"
-          state: "failure"
-          token: "${{ github.token }}"

--- a/.github/workflows/review-destroy.yml
+++ b/.github/workflows/review-destroy.yml
@@ -68,9 +68,3 @@ jobs:
           eval `ssh-agent -s`
           echo "${{ secrets.SSH_PRIVATE_KEY }}" | tr -d '\r' | ssh-add - > /dev/null
           dep review:destroy review --no-interaction
-
-      - name: Delete environment
-        uses: strumwolf/delete-deployment-environment@v2
-        with:
-          token: ${{ github.token }}
-          environment: "Review: ${{ env.REVIEW_NAME }}"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -46,18 +46,7 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       image: ${{ inputs.image }}
-    outputs:
-      deployment_id: ${{ steps.deployment.outputs.deployment_id }}
     steps:
-      - name: Set GitHub deployment status
-        uses: chrnorm/deployment-action@releases/v1
-        id: deployment
-        with:
-          environment: Staging
-          initial_status: "pending"
-          target_url: ${{ inputs.url }}
-          token: "${{ github.token }}"
-
       - name: Checkout repository
         uses: actions/checkout@v2
 
@@ -94,15 +83,6 @@ jobs:
             web/mix-manifest.json
             web/assets
           retention-days: 1
-
-      - name: Update GitHub deployment status (failure)
-        if: failure()
-        uses: chrnorm/deployment-status@releases/v1
-        with:
-          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          target_url: ${{ inputs.url }}
-          state: "failure"
-          token: "${{ github.token }}"
 
   deploy:
     runs-on: self-hosted
@@ -144,21 +124,3 @@ jobs:
           eval `ssh-agent -s`
           echo "${{ secrets.SSH_PRIVATE_KEY }}" | tr -d '\r' | ssh-add - > /dev/null
           dep deploy staging --no-interaction
-
-      - name: Update GitHub deployment status (success)
-        if: success()
-        uses: chrnorm/deployment-status@releases/v1
-        with:
-          deployment_id: ${{ needs.build.outputs.deployment_id }}
-          target_url: ${{ inputs.url }}
-          state: "success"
-          token: "${{ github.token }}"
-
-      - name: Update GitHub deployment status (failure)
-        if: failure()
-        uses: chrnorm/deployment-status@releases/v1
-        with:
-          deployment_id: ${{ needs.build.outputs.deployment_id }}
-          target_url: ${{ inputs.url }}
-          state: "failure"
-          token: "${{ github.token }}"


### PR DESCRIPTION
### Context
Some of the environment jobs have started failing and they don't really serve us any purpose anyway.

GitHub Enterprise makes this much easier (what we have right now is a bit of a hack) and so if we want these back, we can just pay for that.

### Removed
- Environment status jobs

