### PR TITLE
Ubuntu 22.04 on cloud runners

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -44,7 +44,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: ${{ inputs.image }}
     steps:

--- a/.github/workflows/review-deploy.yml
+++ b/.github/workflows/review-deploy.yml
@@ -43,7 +43,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: ${{ inputs.image }}
     steps:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -43,7 +43,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: ${{ inputs.image }}
     steps:


### PR DESCRIPTION
### Context
We're moving everything to Ubuntu 22.04.

### Junior Review
Yes

### Updated
- All cloud runner `runs-on` values to `ubuntu-22.04`
